### PR TITLE
Prevent crash on default color

### DIFF
--- a/Sources/KRTabBar/KRTabBarController.swift
+++ b/Sources/KRTabBar/KRTabBarController.swift
@@ -80,14 +80,12 @@ class KRTabBarController: UITabBarController, UITabBarControllerDelegate {
         }
         
         for (index, viewController) in viewControllers.enumerated() {
-            if let tabBarItem = viewController.tabBarItem as? KRTabBarItem {
-                if let color = tabBarItem.color {
-                    buttonsColors.append(color)
-                }
-            } else {
-                fatalError("set tabBarItem Class as KRTabBarItem and set its color")
-                
+            guard let tabBarItem = viewController.tabBarItem as? KRTabBarItem else {
+                assertionFailure("TabBarItems class must be KRTabBarItem")
+			    return
             }
+            buttonsColors.append(tabBarItem.color)
+			
             let button = UIButton()
             button.tag = index
             button.addTarget(self, action: #selector(didSelectIndex(sender:)), for: .touchUpInside)

--- a/Sources/KRTabBar/KRTabBarItem.swift
+++ b/Sources/KRTabBar/KRTabBarItem.swift
@@ -10,5 +10,5 @@ import UIKit
 
 class KRTabBarItem: UITabBarItem {
     @IBInspectable
-    var color: UIColor?
+    var color: UIColor = UIColor.systemBlue
 }


### PR DESCRIPTION
This PR fixes this issue: https://github.com/kerollesroshdi/KRTabBar/issues/1

KRTabBarItem:
- Made color property non-optional, because the app always crashes if the color is missing.
- Added a default system color by default.
KRTabBarController:
- Reworked conditional in createButtonsStack: second if didn't throw an error, only the first one did + fatalError crashes all builds (including production). Should be better now.